### PR TITLE
fixed for Swift 2 compatibility

### DIFF
--- a/sendMessage/WatchOS2CounterSwift/WatchOS2CounterSwift WatchKit Extension/InterfaceController.swift
+++ b/sendMessage/WatchOS2CounterSwift/WatchOS2CounterSwift WatchKit Extension/InterfaceController.swift
@@ -49,10 +49,11 @@ class InterfaceController: WKInterfaceController, WCSessionDelegate {
     @IBAction func saveCounter() {
         let applicationData = ["counterValue":String(counter)]
         
-        session.sendMessage(applicationData, replyHandler: {([String : AnyObject]) -> Void in
-            // handle reply from iPhone app here
-        }, errorHandler: {(error ) -> Void in
-            // catch any errors here
+        session.sendMessage(applicationData,
+            replyHandler: { replyData in
+                // handle reply from iPhone app here
+            }, errorHandler: { error in
+                // catch any errors here
         })
     }
     


### PR DESCRIPTION
Was getting an error on this block in Xcode 7 Beta 6. Small change, should be backwards compatible to Swift 1.2 and earlier. 
