### PR TITLE
refactored a few swift things

### DIFF
--- a/sendMessage/WatchOS2CounterSwift/WatchOS2CounterSwift WatchKit Extension/InterfaceController.swift
+++ b/sendMessage/WatchOS2CounterSwift/WatchOS2CounterSwift WatchKit Extension/InterfaceController.swift
@@ -14,22 +14,25 @@ import WatchConnectivity
 class InterfaceController: WKInterfaceController, WCSessionDelegate {
     
     @IBOutlet var counterLabel: WKInterfaceLabel!
-    var counter = 0
-    var session : WCSession!
+    
+    private var counter = 0
+    
+    private let session : WCSession? = WCSession.isSupported() ? WCSession.defaultSession() : nil
     
 
+    override init() {
+        super.init()
+        
+        session?.delegate = self
+        session?.activateSession()
+    }
+    
     override func awakeWithContext(context: AnyObject?) {
         super.awakeWithContext(context)
     }
 
     override func willActivate() {
         super.willActivate()
-        
-        if (WCSession.isSupported()) {
-            session = WCSession.defaultSession()
-            session.delegate = self
-            session.activateSession()
-        }
     }
 
     override func didDeactivate() {
@@ -47,17 +50,19 @@ class InterfaceController: WKInterfaceController, WCSessionDelegate {
     }
     
     @IBAction func saveCounter() {
-        let applicationData = ["counterValue":String(counter)]
+        let applicationData = ["counterValue" : counter]
         
-        session.sendMessage(applicationData,
+        session?.sendMessage(applicationData,
             replyHandler: { replyData in
                 // handle reply from iPhone app here
+                print(replyData)
             }, errorHandler: { error in
                 // catch any errors here
+                print(error)
         })
     }
     
-    func setCounterLabelText() {
+    private func setCounterLabelText() {
         counterLabel.setText(String(counter))
     }
     

--- a/sendMessage/WatchOS2CounterSwift/WatchOS2CounterSwift/ViewController.swift
+++ b/sendMessage/WatchOS2CounterSwift/WatchOS2CounterSwift/ViewController.swift
@@ -9,23 +9,52 @@
 import UIKit
 import WatchConnectivity
 
-class ViewController: UIViewController, WCSessionDelegate, UITableViewDataSource {
+class ViewController: UIViewController {
 
     @IBOutlet weak var mainTableView: UITableView!
-    var counterData = [String]()
-    var session: WCSession!
+    
+    private var counterData = [Int]()
+    private let session: WCSession? = WCSession.isSupported() ? WCSession.defaultSession() : nil
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        configureWCSession()
+    }
+    
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        
+        configureWCSession()
+    }
+    
+    private func configureWCSession() {
+        session?.delegate = self;
+        session?.activateSession()
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        if (WCSession.isSupported()) {
-            session = WCSession.defaultSession()
-            session.delegate = self;
-            session.activateSession()
-        }
-        
-        self.mainTableView.reloadData()
     }
+}
+
+// MARK: WCSessionDelegate
+extension ViewController: WCSessionDelegate {
+    
+    func session(session: WCSession, didReceiveMessage message: [String : AnyObject], replyHandler: ([String : AnyObject]) -> Void) {
+        
+        //Use this to update the UI instantaneously (otherwise, takes a little while)
+        dispatch_async(dispatch_get_main_queue()) {
+            if let counterValue = message["counterValue"] as? Int {
+                self.counterData.append(counterValue)
+                self.mainTableView.reloadData()
+            }
+        }
+    }
+}
+
+// MARK: Table View Data Source
+extension ViewController: UITableViewDataSource {
     
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return counterData.count
@@ -33,24 +62,12 @@ class ViewController: UIViewController, WCSessionDelegate, UITableViewDataSource
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cellIdentifier = "CounterCell"
-        let cell = self.mainTableView.dequeueReusableCellWithIdentifier(cellIdentifier, forIndexPath: indexPath)
+        let cell = mainTableView.dequeueReusableCellWithIdentifier(cellIdentifier, forIndexPath: indexPath)
         
-        let counterValueString = self.counterData[indexPath.row]
+        let counterValueString = String(counterData[indexPath.row])
         cell.textLabel?.text = counterValueString
         
         return cell
     }
-    
-    func session(session: WCSession, didReceiveMessage message: [String : AnyObject], replyHandler: ([String : AnyObject]) -> Void) {
-        let counterValue = message["counterValue"] as? String
-        
-        //Use this to update the UI instantaneously (otherwise, takes a little while)
-        dispatch_async(dispatch_get_main_queue()) {
-            self.counterData.append(counterValue!)
-            self.mainTableView.reloadData()
-        }
-    }
-
-
 }
 


### PR DESCRIPTION
- refactored a few Swift semantics
- changed the passed counter to be Int to keep track of the raw data, and so the UI has the flexibility decide how to format it (as a String in this case)
- Is there a reason the tableView is reloaded in viewDidLoad in the ViewController? That should trigger an automatic reload, so I removed the extra call. 
